### PR TITLE
add repository link for npmjs.com (first google result)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "phaxio-official",
   "version": "1.2.2",
   "description": "The official Node.JS library for Phaxio API v2.1.0. https://phaxio.com",
+  "repository": "github:phaxio/phaxio-node",
   "main": "index.js",
   "scripts": {
     "test": "mocha --exit --recursive --no-colors"


### PR DESCRIPTION
I usually search for a package with google, and npmjs is usually the first result. I then click-through to the actual repository for files, issues, etc. 

There's no link https://www.npmjs.com/package/phaxio-official unlike [others](https://www.npmjs.com/package/lodash).